### PR TITLE
Argument names must not be quoted. - missing = for map

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_api_gateway_integration" "api-method-integration" {
   http_method             = "${aws_api_gateway_method.api-method.http_method}"
   integration_http_method = "${var.http_method}"
   type                    = "${var.integration_type}"
-  uri                     = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.lambda_fuction_arn}/invocations"
+  uri                     = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.lambda_function_arn}/invocations"
   content_handling        = "CONVERT_TO_TEXT"
 }
 
@@ -28,11 +28,11 @@ resource "aws_api_gateway_method_response" "ok" {
   http_method = "${aws_api_gateway_method.api-method.http_method}"
   status_code = "200"
 
-  response_models {
+  response_models = {
     "application/json" = "Empty"
   }
 
-  response_parameters {
+  response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = true
     "method.response.header.Access-Control-Allow-Methods" = true
     "method.response.header.Access-Control-Allow-Origin" = true
@@ -50,7 +50,7 @@ resource "aws_api_gateway_integration_response" "ok-integration-response" {
     "application/json" = ""
   }
 
-  response_parameters {
+  response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'${aws_api_gateway_method.api-method.http_method}'"
     "method.response.header.Access-Control-Allow-Origin" = "'*'"

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "authorization" {
   type = "string"
 }
 
-variable "lambda_fuction_arn" {
+variable "lambda_function_arn" {
   type = "string"
 }
 


### PR DESCRIPTION
When importing this module for use, I came across a few map object that were missing = symbol

```terraform init
Initializing modules...
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid argument name

  on ../modules/birkoff-api-method/main.tf line 36, in resource "aws_api_gateway_method_response" "ok":
  36:     "method.response.header.Access-Control-Allow-Headers" = true

Argument names must not be quoted.
```